### PR TITLE
Configure GitHub Actions bot correctly and fix white space issues

### DIFF
--- a/.github/workflows/update-actionlint.yml
+++ b/.github/workflows/update-actionlint.yml
@@ -6,7 +6,7 @@ on:
 
   schedule:
     - cron: '0 0 * * 0' # every Monday at midnight
-  
+
   workflow_dispatch:
 
 jobs:
@@ -17,6 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
+      - uses: fregante/setup-git-user@77c1b5542f14ab6db4b8462d6857e31deb988b09 # v2.0.1
 
       - shell: pwsh
         env:
@@ -27,7 +28,7 @@ jobs:
           # remove the v from the version number
           $latest=$latest.Substring(1)
           Write-Host "Found the lastest version of rhysd/actionlint:$latest"
-           
+
           # pull so we have the info locally
           docker pull rhysd/actionlint:$latest
 
@@ -56,8 +57,6 @@ jobs:
             git checkout -b update-actionlint-$latest
 
             echo "settings.json has changed, committing and pushing"
-            git config --global user.email "bot@github-actions.com"
-            git config --global user.name "GitHub Actions Bot"
             git add settings.json
             git commit -m "Update actionlint version to $latest"
             git push  --set-upstream origin update-actionlint-$latest


### PR DESCRIPTION
This PR implements my suggestion on outsourcing the Git user configuration as discussed in #30.  As I had to touch the file anyway, I took the freedom to also remove a few trailing white space characters in the respective workflow file (2 spaces in line 9, 11 spaces in line 30 / 31) and added a final line break.

I apologise for the inconvenient delay of submission of this PR, the last few weeks were rather demanding and I did not have the time to actively contribute to all projects.

This PR shall fix #30; if you are not interested in this suggestion, @rajbos, please just close it and mark #30 as not planned, as well.