### PR TITLE
Pass SHELLCHECK_OPTS to docker container

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: "Fail the action if errors are found"
     required: false
     default: "true"
+  shellcheck_opts:
+    description: "Custom SHELLCHECK_OPTS"
+    required: false
+    default: ""
 outputs:
   results-file:
     description: "Path to the json results of the linter"
@@ -31,6 +35,7 @@ runs:
     id: run
     env:
       FAILONERRORS: ${{ inputs.fail-on-errors }}
+      SHELLCHECK_OPTS: ${{ inputs.shellcheck_opts }}
     run: |
       # execute rhysd/actionlint as a docker container
 
@@ -49,7 +54,7 @@ runs:
       fi
       
       # run again to get a json result
-      result=$(docker run -v $GITHUB_WORKSPACE:/repo --workdir /repo $actionLintContainer -color -format "{{json .}}")
+      result=$(docker run -v $GITHUB_WORKSPACE:/repo --workdir /repo -e SHELLCHECK_OPTS="${SHELLCHECK_OPTS}" $actionLintContainer -color -format "{{json .}}")
       status=$?
 
       if jq -e . >/dev/null 2>&1 <<<"$result"; then
@@ -74,7 +79,7 @@ runs:
         echo "Actionlint found errors"
         if [[ $FAILONERRORS == "true" ]]; then
           echo "Running the docker container directly to show the errors"
-          docker run -v $GITHUB_WORKSPACE:/repo --workdir /repo $actionLintContainer -color   
+          docker run -v $GITHUB_WORKSPACE:/repo --workdir /repo -e SHELLCHECK_OPTS="${SHELLCHECK_OPTS}" $actionLintContainer -color   
         fi        
       fi
 


### PR DESCRIPTION
Related to #40

Adds support for passing `SHELLCHECK_OPTS` to the Docker container in the `actionlint` GitHub Action.

- Introduces a new input parameter `shellcheck_opts` in `action.yml` to allow users to specify custom `SHELLCHECK_OPTS`.
- Modifies the `docker run` command to include `-e SHELLCHECK_OPTS="${{ inputs.shellcheck_opts }}"`, ensuring that the `SHELLCHECK_OPTS` environment variable is passed to the Docker container.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/devops-actions/actionlint/issues/40?shareId=33676700-593a-4696-90d8-0c20f4577102).