### PR TITLE
Fixing a typo

### DIFF
--- a/.github/workflows/test-local-action.yml
+++ b/.github/workflows/test-local-action.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: actionlint-results
+          name: actionlint-results-local
           path: ${{ steps.action-lint.outputs.results-file }}
 
       - name: Test output file and expected contents
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: actionlint-results
+          name: actionlint-results-failure
           path: ${{ steps.action-lint.outputs.results-file }}
 
       - name: Test output file and expected contents

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This action will run your repository through actionlint and detect common errors
 - And more, check the [actionlint documentation](https://github.com/rhysd/actionlint) for more information
 
 > [!NOTE]
-> Actionlint does _not_ check for external output, like usage of ${{ input.name }} into the shell commands. The reasoning is that to be able to inject something, you need to have write access to the repo (inputs come either from workflow files or workflow_dispatch events.
+> Actionlint does _not_ check for external output, like usage of ${{ input.name }} into the shell commands. The reasoning is that to be able to inject something, you need to have **write** access to the repo (inputs come either from workflow files or workflow_dispatch events).
 
 > [!NOTE]
 > Actionlint unfortunately does **not** support (composite) action definition files.


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/test-local-action.yml` file and an improvement to the `README.md` documentation. The most important changes are:

### Workflow file updates:
Prevent error in check workflow:
* Changed the artifact name in the upload step to `actionlint-results-local` for local action tests. (`.github/workflows/test-local-action.yml`)
* Changed the artifact name in the upload step to `actionlint-results-failure` for failure tests. (`.github/workflows/test-local-action.yml`)

### Documentation improvement:

* Updated the `README.md` to emphasize the requirement of **write** access for injecting inputs into shell commands. (`README.md`)