### PR TITLE
chore: add actions-example-checker workflow

### DIFF
--- a/.github/workflows/actions-example-checker.yml
+++ b/.github/workflows/actions-example-checker.yml
@@ -1,0 +1,12 @@
+name: Validate Action Examples
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-examples:
+    uses: devops-actions/.github/.github/workflows/actions-example-checker.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
Adds the `actions-example-checker` reusable workflow to validate documentation examples against the action schema, matching the setup used in other repos (e.g. `action-get-tag`).