### PR TITLE
chore: group github-actions dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds a \groups.github-actions\ entry (pattern \*\) to the github-actions ecosystem update(s) in dependabot.yml, so future action version bumps are batched into a single PR instead of one per action.