### PR TITLE
fix: skip issue-comment-tag step on push events

### DIFF
--- a/.github/workflows/issue-pr-create.yml
+++ b/.github/workflows/issue-pr-create.yml
@@ -30,6 +30,7 @@ jobs:
            
 
         - uses: devops-actions/issue-comment-tag@3a605c5f21e15e5b963c866421bf4189bcc32310 # v0.1.10
+          if: ${{ github.event_name != 'push' }}
           with:
             team: ${{ vars.TAG_TEAM }}
             issue: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Problem
The `issue-pr-create.yml` workflow triggers on `issues`, `pull_request`, **and** on `push` when the workflow file itself changes (the push trigger was added intentionally in 33ab735 to smoke-test workflow changes).

Dependabot PRs that bump actions used in this workflow (e.g. `step-security/harden-runner`, `devops-actions/issue-comment-tag`) modify the file, so the push to the Dependabot branch triggers the `notify` job. On push events there is no issue or pull request in the event context, so the `issue-comment-tag` step fails with:

> Either parameters 'pr' or 'issue' is required. Please provide one of them.

Failed run: https://github.com/devops-actions/actionlint/actions/runs/32712018578/job/99410124122
This currently blocks Dependabot PRs such as #213.

## Fix
Gate the `issue-comment-tag` step with `if: ${{ github.event_name != 'push' }}` so push smoke-test runs end green, while real issue/pull_request events still notify. The push trigger itself and the context-echo step are kept, preserving the original smoke-test intent.

## Verification
Ran actionlint v1.7.12 (the version pinned in `settings.json`) against the changed workflow: no errors.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
